### PR TITLE
feat: Resolve #43 - Create MarketUpdate-to-Edge translator

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 thiserror = "1.0"
 rust_decimal = { version = "1.33", features = ["macros"] }
 rust_decimal_macros = "1.33"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Aptos SDK - direct git dependency, features enabled here.
 aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", branch = "devnet" }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,4 +1,6 @@
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 
 /// Represents a price, typically using a high-precision decimal type.
@@ -22,7 +24,7 @@ impl fmt::Display for Quantity {
 }
 
 /// Represents a financial asset, identified by a symbol string.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Asset(pub String);
 
 impl fmt::Display for Asset {
@@ -158,6 +160,33 @@ pub struct CycleEval {
     pub gas_estimate: u64,
     pub gas_unit_price: rust_decimal::Decimal,
     pub net_profit: rust_decimal::Decimal,
+}
+
+/// Token pair for CLMM pools
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TokenPair {
+    pub token0: String,
+    pub token1: String,
+}
+
+/// Information about a specific tick in the CLMM
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TickInfo {
+    pub liquidity_net: i128,
+    pub liquidity_gross: u128,
+}
+
+/// Market update to be sent to the detector
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketUpdate {
+    pub pool_address: String,
+    pub dex_name: String,
+    pub token_pair: TokenPair,
+    pub sqrt_price: u128,
+    pub liquidity: u128,
+    pub tick: u32,
+    pub fee_bps: u32,
+    pub tick_map: HashMap<i32, TickInfo>,
 }
 
 #[cfg(test)]

--- a/crates/detector/Cargo.toml
+++ b/crates/detector/Cargo.toml
@@ -8,7 +8,7 @@ petgraph = "0.6"
 tokio = { version = "1", features = ["full"] }
 common = { path = "../common" }
 aptos-sdk = { git = "https://github.com/aptos-labs/aptos-core", branch = "devnet" }
-rust_decimal = "1.32"
+rust_decimal = { version = "1.32", features = ["maths"] }
 rust_decimal_macros = "1.32"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/detector/src/graph.rs
+++ b/crates/detector/src/graph.rs
@@ -31,6 +31,15 @@ pub enum PoolModel {
     },
 }
 
+impl PoolModel {
+    pub fn fee_bps(&self) -> u16 {
+        match self {
+            PoolModel::ConstantProduct { fee_bps, .. } => *fee_bps,
+            PoolModel::ConcentratedLiquidity { fee_bps, .. } => *fee_bps,
+        }
+    }
+}
+
 /// Represents a tick in a concentrated liquidity pool.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Tick {

--- a/crates/detector/src/lib.rs
+++ b/crates/detector/src/lib.rs
@@ -9,6 +9,7 @@ pub mod prelude;
 pub mod service;
 pub mod sizing;
 pub mod traits;
+pub mod translator;
 
 use crate::bellman_ford::DetectorConfig;
 use crate::service::{DetectorService, DexAdapters, PriceStream};

--- a/crates/detector/src/translator.rs
+++ b/crates/detector/src/translator.rs
@@ -1,0 +1,164 @@
+use crate::graph::{Edge, PoolModel, Tick};
+use common::types::{Asset, MarketUpdate, TradingPair};
+use dex_adapter_trait::Exchange;
+use rust_decimal::{Decimal, MathematicalOps};
+use std::str::FromStr;
+use std::time::Instant;
+
+/// Converts a `MarketUpdate` from the Market Data Ingestor into an `Edge` for the price graph.
+///
+/// The function handles the translation of asset types, DEX names, and tick data into the
+/// `ConcentratedLiquidity` model required by the detector's graph.
+pub fn market_update_to_edge(market_update: &MarketUpdate) -> Result<Edge, anyhow::Error> {
+    // 1. Convert string-based token pairs to Asset types.
+    let asset_x = Asset::from_str(&market_update.token_pair.token0)?;
+    let asset_y = Asset::from_str(&market_update.token_pair.token1)?;
+
+    // 2. Map the DEX name string to the Exchange enum.
+    let exchange = Exchange::from_str(&market_update.dex_name)?;
+
+    // 3. Convert the tick map into a vector of `Tick` structs for the CLMM model.
+    // The price at each tick is calculated as p(i) = 1.0001^i.
+    let ticks: Vec<Tick> = market_update
+        .tick_map
+        .iter()
+        .map(|(tick_index, tick_info)| {
+            // Price calculation: p(i) = 1.0001^i
+            // Using Decimal::powd for precision.
+            let price = Decimal::from_str("1.0001")
+                .unwrap()
+                .powd(Decimal::from(*tick_index));
+
+            // Convert liquidity from u128 to Decimal.
+            let liquidity_gross = Decimal::from(tick_info.liquidity_gross);
+
+            Tick {
+                price,
+                liquidity_gross,
+            }
+        })
+        .collect();
+
+    // 4. Construct the Edge.
+    let edge = Edge {
+        pair: TradingPair { asset_x, asset_y },
+        exchange,
+        model: PoolModel::ConcentratedLiquidity {
+            ticks,
+            fee_bps: market_update.fee_bps as u16, // Safely cast from u32 to u16
+        },
+        last_updated: Instant::now(),
+    };
+
+    Ok(edge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::types::{MarketUpdate, TickInfo, TokenPair};
+    use rust_decimal::MathematicalOps;
+    use rust_decimal_macros::dec;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_market_update_to_edge_conversion() {
+        // 1. Create a sample MarketUpdate.
+        let mut tick_map = HashMap::new();
+        tick_map.insert(
+            -20,
+            TickInfo {
+                liquidity_net: 1000,
+                liquidity_gross: 10000,
+            },
+        );
+        tick_map.insert(
+            10,
+            TickInfo {
+                liquidity_net: -500,
+                liquidity_gross: 5000,
+            },
+        );
+
+        let market_update = MarketUpdate {
+            pool_address: "0x1234".to_string(),
+            dex_name: "Tapp".to_string(),
+            token_pair: TokenPair {
+                token0: "0x1::aptos_coin::AptosCoin".to_string(),
+                token1: "0x1::coin::USDC".to_string(),
+            },
+            sqrt_price: 123456789,
+            liquidity: 100000,
+            tick: 123,
+            fee_bps: 30,
+            tick_map,
+        };
+
+        // 2. Perform the conversion.
+        let result = market_update_to_edge(&market_update);
+        assert!(result.is_ok());
+        let edge = result.unwrap();
+
+        // 3. Assert the fields of the resulting Edge.
+        let expected_asset_x = Asset::from_str("0x1::aptos_coin::AptosCoin").unwrap();
+        let expected_asset_y = Asset::from_str("0x1::coin::USDC").unwrap();
+
+        assert_eq!(edge.pair.asset_x, expected_asset_x);
+        assert_eq!(edge.pair.asset_y, expected_asset_y);
+        assert_eq!(edge.exchange, Exchange::Tapp);
+        assert_eq!(edge.model.fee_bps(), 30);
+
+        // Check the ConcentratedLiquidity model and its ticks.
+        if let PoolModel::ConcentratedLiquidity { ticks, fee_bps } = edge.model {
+            assert_eq!(fee_bps, 30);
+            assert_eq!(ticks.len(), 2);
+
+            // Verify tick for index -20
+            let tick_minus_20 = ticks
+                .iter()
+                .find(|t| {
+                    let expected_price = dec!(1.0001).powd(dec!(-20));
+                    // Compare with a tolerance for floating point inaccuracies
+                    (t.price - expected_price).abs() < dec!(1e-12)
+                })
+                .unwrap();
+            assert_eq!(tick_minus_20.liquidity_gross, dec!(10000));
+
+            // Verify tick for index 10
+            let tick_10 = ticks
+                .iter()
+                .find(|t| {
+                    let expected_price = dec!(1.0001).powd(dec!(10));
+                    (t.price - expected_price).abs() < dec!(1e-12)
+                })
+                .unwrap();
+            assert_eq!(tick_10.liquidity_gross, dec!(5000));
+        } else {
+            panic!("Expected ConcentratedLiquidity model");
+        }
+    }
+
+    #[test]
+    fn test_invalid_dex_name() {
+        let market_update = MarketUpdate {
+            pool_address: "0x1234".to_string(),
+            dex_name: "InvalidDex".to_string(),
+            token_pair: TokenPair {
+                token0: "0x1::aptos_coin::AptosCoin".to_string(),
+                token1: "0x1::coin::USDC".to_string(),
+            },
+            sqrt_price: 123456789,
+            liquidity: 100000,
+            tick: 123,
+            fee_bps: 30,
+            tick_map: HashMap::new(),
+        };
+
+        let result = market_update_to_edge(&market_update);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid exchange: InvalidDex"
+        );
+    }
+}

--- a/crates/market-data-ingestor/src/processor.rs
+++ b/crates/market-data-ingestor/src/processor.rs
@@ -1,8 +1,6 @@
-use crate::{
-    config::IndexerProcessorConfig,
-    steps::{ClmmParserStep, DetectorPushStep, EventExtractorStep},
-    types::MarketUpdate,
-};
+use crate::config::IndexerProcessorConfig;
+use crate::steps::{ClmmParserStep, DetectorPushStep, EventExtractorStep};
+use crate::types::MarketUpdate;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStream;
 use tokio::sync::{mpsc, oneshot};

--- a/crates/market-data-ingestor/src/steps/detector_push.rs
+++ b/crates/market-data-ingestor/src/steps/detector_push.rs
@@ -1,4 +1,4 @@
-use crate::types::MarketUpdate;
+use super::super::types::MarketUpdate;
 use anyhow::Result;
 use tokio::sync::mpsc;
 use tracing::{debug, error};

--- a/crates/market-data-ingestor/src/types.rs
+++ b/crates/market-data-ingestor/src/types.rs
@@ -1,12 +1,6 @@
+pub use common::types::{MarketUpdate, TickInfo, TokenPair};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-/// Token pair for CLMM pools
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct TokenPair {
-    pub token0: String,
-    pub token1: String,
-}
 
 /// Configuration for a single DEX
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,26 +30,6 @@ pub struct PoolState {
     pub tick_spacing: Option<i32>,
     pub tick_map: HashMap<i32, TickInfo>,
     pub token_pair: TokenPair,
-}
-
-/// Information about a specific tick in the CLMM
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TickInfo {
-    pub liquidity_net: i128,
-    pub liquidity_gross: u128,
-}
-
-/// Market update to be sent to the detector
-#[derive(Debug, Clone)]
-pub struct MarketUpdate {
-    pub pool_address: String,
-    pub dex_name: String,
-    pub token_pair: TokenPair,
-    pub sqrt_price: u128,
-    pub liquidity: u128,
-    pub tick: u32,
-    pub fee_bps: u32,
-    pub tick_map: HashMap<i32, TickInfo>,
 }
 
 /// Tick structure from event data


### PR DESCRIPTION
Closes #43.

This PR introduces the `MarketUpdate` to `Edge` translator as a new module in `crates/detector/src/translator.rs`. This is a foundational component for processing real market data by converting incoming `MarketUpdate` structs from the MDI into `Edge` structs for the Detector's price graph.\n\nIncludes unit tests to validate the translation logic.