### PR TITLE
refactor(common): remove PoolFilter from common crate

### DIFF
--- a/bin/arb-bot/src/main.rs
+++ b/bin/arb-bot/src/main.rs
@@ -10,7 +10,7 @@ use market_data_ingestor::{IndexerProcessorConfig, MarketDataIngestorProcessor};
 use std::collections::HashMap;
 use std::fs;
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info};
 
 /// Command line arguments for arb-bot.
@@ -53,8 +53,8 @@ async fn main() -> Result<()> {
         IndexerProcessorConfig::new(config.transaction_stream_config, config.market_data_config);
 
     // --- New Channel Setup ---
-    // Channel for MDI -> Detector communication
-    let (detector_tx, detector_rx) = broadcast::channel(100);
+    // Channel for MDI -> Detector communication (block messages + updates)
+    let (detector_tx, detector_rx) = mpsc::channel(100);
     // Channel for Detector -> Risk Manager communication
     let (opportunity_tx, mut opportunity_rx) = mpsc::channel(100);
 
@@ -68,12 +68,9 @@ async fn main() -> Result<()> {
 
     // --- Instantiate and Spawn MDI ---
     // The MDI needs a sender for the *broadcast* channel now.
-    let _mdi_sender = detector_tx.clone();
     let (mdi_shutdown_tx, mdi_shutdown_rx) = oneshot::channel();
     let mut mdi = MarketDataIngestorProcessor::new(mdi_config, adapters).await?;
-    // TODO: The MDI needs to be updated to send DetectorMessage enums instead of just MarketUpdates.
-    // For now, we will not connect it.
-    // mdi.set_update_sender(mdi_sender);
+    mdi.set_update_sender(detector_tx.clone());
     mdi.set_shutdown_receiver(mdi_shutdown_rx);
     let mdi_handle = tokio::spawn(async move { mdi.run_processor().await });
 
@@ -88,6 +85,7 @@ async fn main() -> Result<()> {
                     block_number,
                     timestamp: Utc::now(),
                 })
+                .await
                 .unwrap();
 
             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -107,6 +105,7 @@ async fn main() -> Result<()> {
                     fee_bps: 0,
                     tick_map: HashMap::new(),
                 }))
+                .await
                 .unwrap();
 
             tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -114,6 +113,7 @@ async fn main() -> Result<()> {
             info!("Sending dummy BlockEnd for block {}", block_number);
             test_sender
                 .send(DetectorMessage::BlockEnd { block_number })
+                .await
                 .unwrap();
 
             block_number += 1;

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -162,6 +162,7 @@ pub struct CycleEval {
     pub net_profit: rust_decimal::Decimal,
 }
 
+
 /// Token pair for CLMM pools
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenPair {
@@ -199,6 +200,8 @@ mod tests {
         let price = Price(dec!(123.45));
         assert_eq!(format!("{}", price), "123.45");
     }
+
+    
 
     #[test]
     fn test_quantity_display() {

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -162,7 +162,6 @@ pub struct CycleEval {
     pub net_profit: rust_decimal::Decimal,
 }
 
-
 /// Token pair for CLMM pools
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TokenPair {
@@ -200,8 +199,6 @@ mod tests {
         let price = Price(dec!(123.45));
         assert_eq!(format!("{}", price), "123.45");
     }
-
-    
 
     #[test]
     fn test_quantity_display() {

--- a/crates/detector/src/service.rs
+++ b/crates/detector/src/service.rs
@@ -10,12 +10,12 @@ use futures::future::join_all;
 use log::{debug, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 /// The core service for the arbitrage detector.
 pub struct DetectorService {
     /// Receives block-aligned messages from the MDI.
-    receiver: broadcast::Receiver<DetectorMessage>,
+    receiver: mpsc::Receiver<DetectorMessage>,
     /// Sends found arbitrage opportunities to the risk manager.
     opportunity_sender: mpsc::Sender<ArbitrageOpportunity>,
     /// The price graph.
@@ -29,7 +29,7 @@ pub struct DetectorService {
 impl DetectorService {
     /// Creates a new `DetectorService`.
     pub fn new(
-        receiver: broadcast::Receiver<DetectorMessage>,
+        receiver: mpsc::Receiver<DetectorMessage>,
         opportunity_sender: mpsc::Sender<ArbitrageOpportunity>,
         strategy_configs: Vec<StrategyConfig>,
     ) -> Result<Self> {
@@ -51,22 +51,12 @@ impl DetectorService {
     /// Starts the main service loop.
     pub async fn run(mut self) -> Result<()> {
         info!("DetectorService started.");
-        loop {
-            match self.receiver.recv().await {
-                Ok(message) => {
-                    if let Err(e) = self.handle_message(message).await {
-                        warn!("Error handling message: {}", e);
-                    }
-                }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!("Detector channel lagged by {} messages.", n);
-                }
-                Err(broadcast::error::RecvError::Closed) => {
-                    info!("Detector channel closed.");
-                    break;
-                }
+        while let Some(message) = self.receiver.recv().await {
+            if let Err(e) = self.handle_message(message).await {
+                warn!("Error handling message: {}", e);
             }
         }
+        info!("Detector channel closed.");
         Ok(())
     }
 

--- a/crates/dex-adapters/Cargo.toml
+++ b/crates/dex-adapters/Cargo.toml
@@ -11,3 +11,4 @@ dashmap = "5.5.3"
 dex-adapter-trait = { path = "../dex-adapter-trait" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+simd-json = { version = "0.15.1", features = ["serde_impl"] }

--- a/crates/dex-adapters/src/lib.rs
+++ b/crates/dex-adapters/src/lib.rs
@@ -85,7 +85,7 @@ impl DexAdapter for HyperionAdapter {
                     liquidity: snapshot.liquidity,
                     tick: snapshot.tick,
                     // Assuming fee_rate is in basis points, e.g., 30 for 0.30%
-                    fee_bps: (snapshot.fee_rate) as u32,
+                    fee_bps: snapshot.fee_rate as u32,
                     tick_map: snapshot.tick_map,
                 };
                 self.pools.insert(snapshot.pool_id, state);
@@ -164,7 +164,7 @@ impl DexAdapter for ThalaAdapter {
                     sqrt_price: snapshot.sqrt_price,
                     liquidity: snapshot.liquidity,
                     tick: snapshot.tick,
-                    fee_bps: (snapshot.fee_rate) as u32,
+                    fee_bps: snapshot.fee_rate as u32,
                     tick_map: snapshot.tick_map,
                 };
                 self.pools.insert(snapshot.pool_id, state);

--- a/crates/dex-adapters/src/lib.rs
+++ b/crates/dex-adapters/src/lib.rs
@@ -4,6 +4,7 @@ use common::types::{Event, MarketUpdate, TickInfo, TokenPair};
 use dashmap::DashMap;
 use dex_adapter_trait::DexAdapter;
 use serde::Deserialize;
+use simd_json::serde::from_slice as simd_from_slice;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -74,8 +75,10 @@ impl DexAdapter for HyperionAdapter {
 
         match event_name {
             "PoolSnapshot" => {
-                let snapshot: PoolSnapshotData = serde_json::from_str(&event.data)
-                    .context("Failed to deserialize PoolSnapshotData")?;
+                // Use simd-json for faster in-place JSON parsing
+                let mut raw = event.data.clone().into_bytes();
+                let snapshot: PoolSnapshotData = simd_from_slice(&mut raw)
+                    .context("Failed to deserialize PoolSnapshotData with simd-json")?;
                 let state = PoolState {
                     token_pair: TokenPair {
                         token0: snapshot.token_a,
@@ -93,8 +96,9 @@ impl DexAdapter for HyperionAdapter {
                 Ok(None)
             }
             "SwapEvent" | "SwapAfterEvent" => {
-                let swap: SwapEventData = serde_json::from_str(&event.data)
-                    .context("Failed to deserialize SwapEventData")?;
+                let mut raw = event.data.clone().into_bytes();
+                let swap: SwapEventData = simd_from_slice(&mut raw)
+                    .context("Failed to deserialize SwapEventData with simd-json")?;
                 let pool_id = swap.pool_id.clone();
 
                 if let Some(mut pool_state) = self.pools.get_mut(&pool_id) {
@@ -154,8 +158,9 @@ impl DexAdapter for ThalaAdapter {
 
         match event_name {
             "PoolSnapshot" => {
-                let snapshot: PoolSnapshotData = serde_json::from_str(&event.data)
-                    .context("Failed to deserialize PoolSnapshotData for Thala")?;
+                let mut raw = event.data.clone().into_bytes();
+                let snapshot: PoolSnapshotData = simd_from_slice(&mut raw)
+                    .context("Failed to deserialize PoolSnapshotData for Thala with simd-json")?;
                 let state = PoolState {
                     token_pair: TokenPair {
                         token0: snapshot.token_a,
@@ -171,8 +176,9 @@ impl DexAdapter for ThalaAdapter {
                 Ok(None)
             }
             "SwapEvent" | "SwapAfterEvent" => {
-                let swap: SwapEventData = serde_json::from_str(&event.data)
-                    .context("Failed to deserialize SwapEventData for Thala")?;
+                let mut raw = event.data.clone().into_bytes();
+                let swap: SwapEventData = simd_from_slice(&mut raw)
+                    .context("Failed to deserialize SwapEventData for Thala with simd-json")?;
                 let pool_id = swap.pool_id.clone();
 
                 if let Some(mut pool_state) = self.pools.get_mut(&pool_id) {

--- a/crates/market-data-ingestor/Cargo.toml
+++ b/crates/market-data-ingestor/Cargo.toml
@@ -25,6 +25,9 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Date/time for BlockStart timestamps
+chrono = { version = "0.4", features = ["serde"] }
+
 # HTTP client for REST API calls
 reqwest = { version = "0.11", features = ["json"] }
 

--- a/crates/market-data-ingestor/src/bin/mdi-recorder.rs
+++ b/crates/market-data-ingestor/src/bin/mdi-recorder.rs
@@ -3,8 +3,8 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::TransactionStream;
-use config_lib::load_config_from_path;
 use clap::Parser;
+use config_lib::load_config_from_path;
 use prost::Message;
 use tokio::runtime::Runtime;
 
@@ -33,8 +33,7 @@ fn main() -> anyhow::Result<()> {
             .install_default()
             .unwrap();
         // Load config and extract transaction stream settings
-        let cfg = load_config_from_path(args.config_path.to_str().unwrap())
-            .await?;
+        let cfg = load_config_from_path(args.config_path.to_str().unwrap()).await?;
         let indexer_cfg = IndexerProcessorConfig::new(
             cfg.transaction_stream_config.clone(),
             cfg.market_data_config.clone(),

--- a/crates/market-data-ingestor/src/bin/proto-to-json.rs
+++ b/crates/market-data-ingestor/src/bin/proto-to-json.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use bytes::Buf;
+use std::path::PathBuf;
 
 use clap::Parser;
 use prost::Message;

--- a/crates/market-data-ingestor/src/data_source.rs
+++ b/crates/market-data-ingestor/src/data_source.rs
@@ -1,17 +1,17 @@
-use async_trait::async_trait;
 use anyhow::Result;
 use aptos_indexer_processor_sdk::aptos_indexer_transaction_stream::{
     TransactionStream, TransactionStreamConfig, TransactionsPBResponse,
 };
+use async_trait::async_trait;
 
+use aptos_indexer_processor_sdk::aptos_protos::transaction::v1::Transaction as ProtoTransaction;
+use bytes::Bytes;
+use prost::Message;
+use serde::{Deserialize, Serialize};
 use std::{
     fs,
     time::{Duration, Instant},
 };
-use prost::Message;
-use bytes::Bytes;
-use serde::{Deserialize, Serialize};
-use aptos_indexer_processor_sdk::aptos_protos::transaction::v1::Transaction as ProtoTransaction;
 /// Abstracts the source of transaction data, allowing for live or prerecorded streams.
 #[async_trait]
 pub trait DataSource: Send {

--- a/crates/market-data-ingestor/src/processor.rs
+++ b/crates/market-data-ingestor/src/processor.rs
@@ -1,14 +1,14 @@
+use crate::data_source::{DataSource as SourceTrait, FileSource, GrpcSource};
 use crate::ingestor_config::IndexerProcessorConfig;
 use crate::steps::{DetectorPushStep, EventExtractorStep, FilterStep, Parser};
 use crate::types::MarketUpdate;
 use anyhow::Result;
+use config_lib::DataSource as DataSourceConfig;
 use dex_adapter_trait::DexAdapter;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
-use crate::data_source::{DataSource as SourceTrait, FileSource, GrpcSource};
-use config_lib::DataSource as DataSourceConfig;
 
 pub struct MarketDataIngestorProcessor {
     config: IndexerProcessorConfig,
@@ -62,11 +62,12 @@ impl MarketDataIngestorProcessor {
 
         // Select data source (gRPC live stream or file replay) from config
         let mut source: Box<dyn SourceTrait> = match &self.config.market_data_config.data_source {
-            DataSourceConfig::Grpc => Box::new(
-                GrpcSource::new(self.config.transaction_stream_config.clone()).await?,
-            ),
-            DataSourceConfig::File { path, replay_speed } =>
-                Box::new(FileSource::new(path.clone(), *replay_speed)?),
+            DataSourceConfig::Grpc => {
+                Box::new(GrpcSource::new(self.config.transaction_stream_config.clone()).await?)
+            }
+            DataSourceConfig::File { path, replay_speed } => {
+                Box::new(FileSource::new(path.clone(), *replay_speed)?)
+            }
         };
 
         // Create processing steps
@@ -103,12 +104,12 @@ impl MarketDataIngestorProcessor {
                                     Ok(events) if !events.is_empty() => {
                                         // Parse events into market updates
                                         match self.parser.process_events(&events) {
-                                            Ok(updates) if !updates.is_empty() => {
-                                                // Apply filter step to the batch of market updates
-                                                let filtered = self.filter_step.filter(updates);
-                                                if !filtered.is_empty() {
+                                            Ok(mut updates) if !updates.is_empty() => {
+                                                // Filter in-place to drop unwanted pools
+                                                self.filter_step.apply(&mut updates);
+                                                if !updates.is_empty() {
                                                     // Push updates to detector
-                                                    if let Err(e) = detector_push.push_updates(filtered).await {
+                                                    if let Err(e) = detector_push.push_updates(updates).await {
                                                         error!(version = version, error = %e, "Failed to push updates");
                                                     }
                                                 }

--- a/crates/market-data-ingestor/src/processor.rs
+++ b/crates/market-data-ingestor/src/processor.rs
@@ -1,8 +1,9 @@
 use crate::data_source::{DataSource as SourceTrait, FileSource, GrpcSource};
 use crate::ingestor_config::IndexerProcessorConfig;
 use crate::steps::{DetectorPushStep, EventExtractorStep, FilterStep, Parser};
-use crate::types::MarketUpdate;
 use anyhow::Result;
+use chrono::Utc;
+use common::types::DetectorMessage;
 use config_lib::DataSource as DataSourceConfig;
 use dex_adapter_trait::DexAdapter;
 use std::collections::HashMap;
@@ -14,7 +15,7 @@ pub struct MarketDataIngestorProcessor {
     config: IndexerProcessorConfig,
     parser: Parser,
     filter_step: FilterStep,
-    update_sender: Option<mpsc::Sender<MarketUpdate>>,
+    update_sender: Option<mpsc::Sender<DetectorMessage>>,
     shutdown_rx: Option<oneshot::Receiver<()>>,
 }
 
@@ -35,7 +36,8 @@ impl MarketDataIngestorProcessor {
     }
 
     /// Set the channel sender for pushing updates to the detector
-    pub fn set_update_sender(&mut self, sender: mpsc::Sender<MarketUpdate>) {
+    /// Set the channel sender for pushing detector messages (BlockStart/Updates/BlockEnd)
+    pub fn set_update_sender(&mut self, sender: mpsc::Sender<DetectorMessage>) {
         self.update_sender = Some(sender);
     }
 
@@ -96,6 +98,12 @@ impl MarketDataIngestorProcessor {
                                 num_transactions = response.transactions.len(),
                                 "Received transaction batch"
                             );
+
+                            // Emit BlockStart before processing this block
+                            detector_push.push(DetectorMessage::BlockStart {
+                                block_number: response.start_version,
+                                timestamp: Utc::now(),
+                            }).await?;
                             for transaction in response.transactions {
                                 let version = transaction.version;
 
@@ -109,8 +117,10 @@ impl MarketDataIngestorProcessor {
                                                 self.filter_step.apply(&mut updates);
                                                 if !updates.is_empty() {
                                                     // Push updates to detector
-                                                    if let Err(e) = detector_push.push_updates(updates).await {
-                                                        error!(version = version, error = %e, "Failed to push updates");
+                                                    for update in updates {
+                                                        if let Err(e) = detector_push.push(DetectorMessage::MarketUpdate(update)).await {
+                                                            error!(version = version, error = %e, "Failed to send MarketUpdate message");
+                                                        }
                                                     }
                                                 }
                                             }
@@ -126,6 +136,8 @@ impl MarketDataIngestorProcessor {
                                     }
                                 }
                             }
+                            // Emit BlockEnd after processing this block
+                            detector_push.push(DetectorMessage::BlockEnd { block_number: response.end_version }).await?;
                         }
                         Err(e) => {
                             error!(error = %e, "Error receiving transaction batch");

--- a/crates/market-data-ingestor/src/steps/detector_push.rs
+++ b/crates/market-data-ingestor/src/steps/detector_push.rs
@@ -1,32 +1,26 @@
-use super::super::types::MarketUpdate;
 use anyhow::Result;
+use common::types::DetectorMessage;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
-/// Step that pushes market updates to the detector via a channel
+/// Step that pushes detector messages (BlockStart/MarketUpdate/BlockEnd).
 pub struct DetectorPushStep {
-    sender: mpsc::Sender<MarketUpdate>,
+    sender: mpsc::Sender<DetectorMessage>,
 }
 
 impl DetectorPushStep {
-    pub fn new(sender: mpsc::Sender<MarketUpdate>) -> Self {
+    pub fn new(sender: mpsc::Sender<DetectorMessage>) -> Self {
         Self { sender }
     }
 
-    pub async fn push_updates(&self, updates: Vec<MarketUpdate>) -> Result<()> {
-        for update in updates {
-            debug!(
-                pool = update.pool_address,
-                dex = update.dex_name,
-                "Pushing market update to detector"
-            );
+    /// Send a single detector message to the receiver.
+    pub async fn push(&self, msg: DetectorMessage) -> Result<()> {
+        debug!(?msg, "Pushing detector message");
 
-            if let Err(e) = self.sender.send(update).await {
-                error!(error = %e, "Failed to send update to detector");
-                return Err(anyhow::anyhow!("Channel send failed: {}", e));
-            }
+        if let Err(e) = self.sender.send(msg).await {
+            error!(error = %e, "Failed to send detector message");
+            return Err(anyhow::anyhow!("Channel send failed: {}", e));
         }
-
         Ok(())
     }
 }

--- a/crates/market-data-ingestor/src/steps/event_extractor.rs
+++ b/crates/market-data-ingestor/src/steps/event_extractor.rs
@@ -11,11 +11,15 @@ pub struct EventExtractorStep {
 
 impl EventExtractorStep {
     pub fn new(dex_configs: Vec<DexConfig>) -> Self {
-        let mut relevant_event_types = HashSet::new();
+        // Pre-allocate and build full event-type keys once to avoid repeated re-allocations
+        let total = dex_configs.iter().map(|d| d.events.len()).sum();
+        let mut relevant_event_types = HashSet::with_capacity(total);
         for dex in dex_configs {
             for event_suffix in dex.events.values() {
-                let full_event_type = format!("{}{}", dex.module_address, event_suffix);
-                relevant_event_types.insert(full_event_type);
+                let mut key = String::with_capacity(dex.module_address.len() + event_suffix.len());
+                key.push_str(&dex.module_address);
+                key.push_str(event_suffix);
+                relevant_event_types.insert(key);
             }
         }
         info!(

--- a/crates/market-data-ingestor/src/steps/filter.rs
+++ b/crates/market-data-ingestor/src/steps/filter.rs
@@ -1,0 +1,105 @@
+use config_lib::FilterConfig;
+use crate::types::MarketUpdate;
+use common::types::TokenPair;
+
+/// Filter criteria for selecting which CLMM pools to ingest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PoolFilter {
+    /// All pools.
+    All,
+    /// All pools containing this token symbol.
+    Token(String),
+    /// Specific token pairs (unordered).
+    TokenPairs(Vec<(String, String)>),
+}
+
+impl PoolFilter {
+    /// Returns true if the given token pair matches this filter.
+    pub fn matches(&self, pair: &TokenPair) -> bool {
+        match self {
+            PoolFilter::All => true,
+            PoolFilter::Token(tok) => &pair.token0 == tok || &pair.token1 == tok,
+            PoolFilter::TokenPairs(pairs) => pairs.iter().any(|(a, b)|
+                (a == &pair.token0 && b == &pair.token1) || (a == &pair.token1 && b == &pair.token0)
+            ),
+        }
+    }
+}
+
+/// A processing step that filters `MarketUpdate`s based on token or token-pair criteria.
+/// A processing step that filters `MarketUpdate`s based on token or token-pair criteria.
+pub struct FilterStep {
+    filter: PoolFilter,
+}
+
+impl FilterStep {
+    /// Create a new `FilterStep` from the shared configuration filter.
+    pub fn new(cfg: &FilterConfig) -> Self {
+        let filter = match cfg {
+            FilterConfig::All => PoolFilter::All,
+            FilterConfig::Token { token } => PoolFilter::Token(token.clone()),
+            FilterConfig::TokenPairs { token_pairs } => PoolFilter::TokenPairs(token_pairs.clone()),
+        };
+        FilterStep { filter }
+    }
+
+    /// Apply the filter to a batch of market updates, dropping non-matching pools.
+    pub fn filter(&self, updates: Vec<MarketUpdate>) -> Vec<MarketUpdate> {
+        updates
+            .into_iter()
+            .filter(|u| self.filter.matches(&u.token_pair))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::types::TokenPair;
+    use config_lib::FilterConfig;
+
+    fn mk_update(pair: (&str, &str)) -> MarketUpdate {
+        MarketUpdate {
+            pool_address: "p".to_string(),
+            dex_name: "d".to_string(),
+            token_pair: TokenPair { token0: pair.0.to_string(), token1: pair.1.to_string() },
+            sqrt_price: 0,
+            liquidity: 0,
+            tick: 0,
+            fee_bps: 0,
+            tick_map: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_filter_step_token_pairs() {
+        let cfg = FilterConfig::TokenPairs { token_pairs: vec![("A".into(), "B".into())] };
+        let step = FilterStep::new(&cfg);
+        let updates = vec![mk_update(("A","B")), mk_update(("B","C"))];
+        let out = step.filter(updates);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].token_pair, TokenPair { token0: "A".into(), token1: "B".into() });
+    }
+
+    #[test]
+    fn test_filter_step_token_all() {
+        let cfg = FilterConfig::All;
+        let step = FilterStep::new(&cfg);
+        let updates = vec![mk_update(("X","Y")), mk_update(("Y","Z"))];
+        let out = step.filter(updates.clone());
+        // All updates should pass filter
+        assert_eq!(out.len(), updates.len());
+        assert_eq!(out[0].token_pair, updates[0].token_pair);
+        assert_eq!(out[1].token_pair, updates[1].token_pair);
+    }
+
+    #[test]
+    fn test_filter_step_token_single() {
+        let cfg = FilterConfig::Token { token: "X".into() };
+        let step = FilterStep::new(&cfg);
+        let updates = vec![mk_update(("X","Y")), mk_update(("A","B"))];
+        let out = step.filter(updates);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].token_pair, TokenPair { token0: "X".into(), token1: "Y".into() });
+    }
+}

--- a/crates/market-data-ingestor/src/steps/filter.rs
+++ b/crates/market-data-ingestor/src/steps/filter.rs
@@ -1,6 +1,6 @@
-use config_lib::FilterConfig;
 use crate::types::MarketUpdate;
 use common::types::TokenPair;
+use config_lib::FilterConfig;
 
 /// Filter criteria for selecting which CLMM pools to ingest.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,9 +19,9 @@ impl PoolFilter {
         match self {
             PoolFilter::All => true,
             PoolFilter::Token(tok) => &pair.token0 == tok || &pair.token1 == tok,
-            PoolFilter::TokenPairs(pairs) => pairs.iter().any(|(a, b)|
+            PoolFilter::TokenPairs(pairs) => pairs.iter().any(|(a, b)| {
                 (a == &pair.token0 && b == &pair.token1) || (a == &pair.token1 && b == &pair.token0)
-            ),
+            }),
         }
     }
 }
@@ -43,12 +43,9 @@ impl FilterStep {
         FilterStep { filter }
     }
 
-    /// Apply the filter to a batch of market updates, dropping non-matching pools.
-    pub fn filter(&self, updates: Vec<MarketUpdate>) -> Vec<MarketUpdate> {
-        updates
-            .into_iter()
-            .filter(|u| self.filter.matches(&u.token_pair))
-            .collect()
+    /// Retain only updates matching the configured token/pair filter.
+    pub fn apply(&self, updates: &mut Vec<MarketUpdate>) {
+        updates.retain(|u| self.filter.matches(&u.token_pair));
     }
 }
 
@@ -62,7 +59,10 @@ mod tests {
         MarketUpdate {
             pool_address: "p".to_string(),
             dex_name: "d".to_string(),
-            token_pair: TokenPair { token0: pair.0.to_string(), token1: pair.1.to_string() },
+            token_pair: TokenPair {
+                token0: pair.0.to_string(),
+                token1: pair.1.to_string(),
+            },
             sqrt_price: 0,
             liquidity: 0,
             tick: 0,
@@ -73,33 +73,48 @@ mod tests {
 
     #[test]
     fn test_filter_step_token_pairs() {
-        let cfg = FilterConfig::TokenPairs { token_pairs: vec![("A".into(), "B".into())] };
+        let cfg = FilterConfig::TokenPairs {
+            token_pairs: vec![("A".into(), "B".into())],
+        };
         let step = FilterStep::new(&cfg);
-        let updates = vec![mk_update(("A","B")), mk_update(("B","C"))];
-        let out = step.filter(updates);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].token_pair, TokenPair { token0: "A".into(), token1: "B".into() });
+        let mut updates = vec![mk_update(("A", "B")), mk_update(("B", "C"))];
+        step.apply(&mut updates);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            updates[0].token_pair,
+            TokenPair {
+                token0: "A".into(),
+                token1: "B".into()
+            }
+        );
     }
 
     #[test]
     fn test_filter_step_token_all() {
         let cfg = FilterConfig::All;
         let step = FilterStep::new(&cfg);
-        let updates = vec![mk_update(("X","Y")), mk_update(("Y","Z"))];
-        let out = step.filter(updates.clone());
+        let mut updates = vec![mk_update(("X", "Y")), mk_update(("Y", "Z"))];
+        let orig = updates.clone();
+        step.apply(&mut updates);
         // All updates should pass filter
-        assert_eq!(out.len(), updates.len());
-        assert_eq!(out[0].token_pair, updates[0].token_pair);
-        assert_eq!(out[1].token_pair, updates[1].token_pair);
+        assert_eq!(updates.len(), orig.len());
+        assert_eq!(updates[0].token_pair, orig[0].token_pair);
+        assert_eq!(updates[1].token_pair, orig[1].token_pair);
     }
 
     #[test]
     fn test_filter_step_token_single() {
         let cfg = FilterConfig::Token { token: "X".into() };
         let step = FilterStep::new(&cfg);
-        let updates = vec![mk_update(("X","Y")), mk_update(("A","B"))];
-        let out = step.filter(updates);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].token_pair, TokenPair { token0: "X".into(), token1: "Y".into() });
+        let mut updates = vec![mk_update(("X", "Y")), mk_update(("A", "B"))];
+        step.apply(&mut updates);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            updates[0].token_pair,
+            TokenPair {
+                token0: "X".into(),
+                token1: "Y".into()
+            }
+        );
     }
 }

--- a/crates/market-data-ingestor/src/steps/mod.rs
+++ b/crates/market-data-ingestor/src/steps/mod.rs
@@ -1,7 +1,9 @@
 pub mod detector_push;
 pub mod event_extractor;
 pub mod parser;
+pub mod filter;
 
 pub use detector_push::DetectorPushStep;
 pub use event_extractor::EventExtractorStep;
 pub use parser::Parser;
+pub use filter::FilterStep;

--- a/crates/market-data-ingestor/src/steps/mod.rs
+++ b/crates/market-data-ingestor/src/steps/mod.rs
@@ -1,9 +1,9 @@
 pub mod detector_push;
 pub mod event_extractor;
-pub mod parser;
 pub mod filter;
+pub mod parser;
 
 pub use detector_push::DetectorPushStep;
 pub use event_extractor::EventExtractorStep;
-pub use parser::Parser;
 pub use filter::FilterStep;
+pub use parser::Parser;

--- a/crates/market-data-ingestor/src/steps/parser.rs
+++ b/crates/market-data-ingestor/src/steps/parser.rs
@@ -14,7 +14,7 @@ impl Parser {
     }
 
     pub fn process_events(&self, events: &[Event]) -> Result<Vec<MarketUpdate>> {
-        let mut updates = Vec::new();
+        let mut updates = Vec::with_capacity(events.len());
         for event in events {
             if let Some(adapter) = self.adapters.get(&event.type_str) {
                 if let Some(update) = adapter.parse_event(event)? {


### PR DESCRIPTION
Move PoolFilter and matching logic into the MDI filter step so that the common
crate remains purely shared types. The new filter step in market-data-ingestor now
defines its own PoolFilter enum and applies it to MarketUpdate batches.

BREAKING CHANGE: common::types no longer exports PoolFilter.
